### PR TITLE
fix compatibility issue with OpenSSL 1.1.0

### DIFF
--- a/xar/configure.ac
+++ b/xar/configure.ac
@@ -329,7 +329,7 @@ dnl Configure libcrypto (part of OpenSSL).
 dnl 
 have_libcrypto="1"
 AC_CHECK_HEADERS([openssl/evp.h], , [have_libcrypto="0"])
-AC_CHECK_LIB([crypto], [OpenSSL_add_all_ciphers], , [have_libcrypto="0"])
+AC_CHECK_LIB([crypto], [CRYPTO_free], , [have_libcrypto="0"])
 if test "x${have_libcrypto}" = "x0" ; then
   AC_MSG_ERROR([Cannot build without libcrypto (OpenSSL)])
 fi


### PR DESCRIPTION
OpenSSL_add_all_ciphers was deprecated in OpenSSL 1.1.0, check CRYPTO_free instead